### PR TITLE
Allow base model to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,16 @@ To allow the web service to connect to your **Watson Speech to Text** service, c
 }
 ```
 
-The application will require a local login. The local user accounts are defined in the file [model/user.json](model/user.json). The pre-defined user/passwords are `user1/user1` and `user2/user2`. You can modify the users as needed.
-
+The application will require a local login. The local user accounts are defined in the file [model/user.json](model/user.json). The pre-defined user/passwords are `user1/user1` and `user2/user2`. The `langModel` and `acousticModel` fields are the names of your custom language and acoustic models which will be created upon logging in if they do not already exist. You can change the `baseModel` field if the base model you are working with is different from our default. Here is an example of user3 using Korean as base language for transcribing. See [Supported language models](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-models#modelsList).
+```json
+{
+  "user3": {
+    "password": "user3",
+    "langModel": "custom-korean-language",
+    "acousticModel": "custom-korean-acoustic",
+    "baseModel": "ko-KR_NarrowbandModel"
+}
+```
 Install and start the application by running the following commands in the root directory:
 
 ```bash

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -30,6 +30,7 @@ class App extends Component {
         localStorage.setItem('username', data.user.username);
         localStorage.setItem('customLanguageModel', data.user.langModel);
         localStorage.setItem('customAcousticModel', data.user.acousticModel);
+        localStorage.setItem('baseModel', data.user.baseModel);
       });
       this.setState({ isAuthenticating: false });
     })

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -2,5 +2,4 @@ export default {
   API_ENDPOINT: 'http://localhost:5000/api',
   WS_ENDPOINT: 'ws://localhost:5000/',
   MAX_AUDIO_SIZE: 15000000,
-  BASE_STT_MODEL: 'en-US_NarrowbandModel'
 };

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -48,6 +48,7 @@ export default class Login extends Component {
         localStorage.setItem('username', data.user.username);
         localStorage.setItem('customLanguageModel', data.user.langModel);
         localStorage.setItem('customAcousticModel', data.user.acousticModel);
+        localStorage.setItem('baseModel', data.user.baseModel);
         this.props.userHasAuthenticated(true);
       });
     })

--- a/client/src/pages/Transcribe.js
+++ b/client/src/pages/Transcribe.js
@@ -350,9 +350,12 @@ export default class Transcribe extends Component {
                     inputRef={languageModelType => this.languageModelType = languageModelType}>
                     { localStorage.getItem('customLanguageModel') &&
                       <option value={localStorage.getItem('customLanguageModel')}>
-                        Custom Language Model</option>
+                        {localStorage.getItem('customLanguageModel')}</option>
                     }
-                    <option value={config.BASE_STT_MODEL}>Base Language Model</option>
+                    { localStorage.getItem('baseModel') &&
+                      <option value={localStorage.getItem('baseModel')}>
+                        Base Language Model ({localStorage.getItem('baseModel')})</option>
+                    }
                   </FormControl>
                   <HelpBlock>Choose your customized language model or the base model.</HelpBlock>
 
@@ -363,9 +366,12 @@ export default class Transcribe extends Component {
                     inputRef={acousticModelType => this.acousticModelType = acousticModelType}>
                     { localStorage.getItem('customAcousticModel') &&
                       <option value={localStorage.getItem('customAcousticModel')}>
-                        Custom Acoustic Model</option>
+                        {localStorage.getItem('customAcousticModel')}</option>
                     }
-                    <option value={config.BASE_STT_MODEL}>Base Acoustic Model</option>
+                    { localStorage.getItem('baseModel') &&
+                      <option value={localStorage.getItem('baseModel')}>
+                      Base Language Model ({localStorage.getItem('baseModel')})</option>
+                    }
                   </FormControl>
                   <HelpBlock>Choose your customized acoustic model or the base model.</HelpBlock>
                 </FormGroup>

--- a/model/user.json
+++ b/model/user.json
@@ -2,11 +2,13 @@
   "user1": {
     "password": "user1",
     "langModel": "custom-model-1",
-    "acousticModel": "acoustic-model-1"
+    "acousticModel": "acoustic-model-1",
+    "baseModel": "en-US_NarrowbandModel"
   },
   "user2": {
     "password": "user2",
     "langModel": "custom-model-2",
-    "acousticModel": "acoustic-model-2"
+    "acousticModel": "acoustic-model-2",
+    "baseModel": "en-US_NarrowbandModel"
   }
 }


### PR DESCRIPTION
The change is to enable base language to be configurable.

The change allows the initial custom language/acoustic creation to have a configurable base language model.  The base language model is configurable using baseModel in the model/user.json. 