### PR TITLE
Add instructions for IBM Cloud CF deployment

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,10 @@
+node_modules/
+client/node_modules/
+*.DS_Store
+README.md
+.github/
+.git/
+.gitignore
+logs
+*.log
+data/

--- a/README.md
+++ b/README.md
@@ -319,24 +319,27 @@ If using the command line, you can directly edit the transcription output file g
 * *409* error message.
 
   > This indicates the service is busy. Try the command again later.
-  
-* Error uploading the audio files:  
+
+* Error uploading the audio files:
 
   > Since the audio files are large (70-90MB), you may encounter error when uploading them because of unstable network connection.  In this case, you can break up the files into smaller files and upload them.  The training for the acoustic model will work the same way.
 
   For example, the command to zip the first audio file as described above:
-  
+
   ```bash
   zip audio-set1.zip -xi Audio/[6-9].wav Audio/[1-7][0-9].wav
   ```
-  
+
   To break up into two smaller files, adjust the regular expression as appropriate:
-  
+
   ```bash
   zip audio-set1a.zip -xi Audio/[6-9].wav Audio/[1-3][0-9].wav
   zip audio-set1b.zip -xi Audio/[4-7][0-9].wav
   ```
-   
+
+# Deploy on IBM Cloud
+
+Instructions for deploying the web application on Cloud Foundry can be found [here](doc/cloud_deploy.md).
 
 # Learn more
 

--- a/doc/cloud-deploy.md
+++ b/doc/cloud-deploy.md
@@ -1,0 +1,86 @@
+# Deploy web app on IBM Cloud using Cloud Foundry
+
+These are instructions for a quick deployment of the web app on IBM Cloud.
+
+## Prerequisites
+
+* Ensure that the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/index.html?locale=en-US#overview)
+  tool is installed locally. Follow the instructions in the linked documentation to
+  configure your environment.
+
+## Update manifest.yml
+
+In the `manifest.yml` file found in the root of the project, change the `route` value to a
+unique route of your choosing by replacing the `your-host` placeholder. For example, route could be
+`- route: my-stt-customizer.mybluemix.net`. Just make sure that the subdomain is not already taken.
+This route corresponds to the URL for which the app will be accessible from. Also, feel free
+to change the value for `name` which will correspond to the name of your Cloud Foundry app.
+
+## Update client config.js
+
+In `client/src/config.js`, update the params `API_ENDPOINT` and `WS_ENDPOINT` to use the route you
+previously specified in the `manifest.yml` file. Using the above example route, this would be:
+
+```
+API_ENDPOINT: 'https://my-stt-customizer.mybluemix.net/api',
+WS_ENDPOINT: 'wss://my-stt-customizer.mybluemix.net/',
+```
+
+> **NOTE**: Both `https` and `wss` are used because Cloud Foundry apps on the IBM Cloud are hosted using HTTPS.
+
+## Make sure build files are up to date
+
+From the root of the project, run:
+
+```bash
+npm run build
+cd client && npm run build
+```
+
+If changes are made to the code, and the app needs to be updated, these will have to be run again.
+
+## Watson credentials configuration
+
+There are two ways to get your Watson STT credentials into your app.
+
+**Option 1**
+
+Use the `services.json` file for which a sample was provided. You only have to fill it out and
+ensure it exists in the root of the project.
+
+**Option 2**
+
+Deploy the app, then connect your instance of the Watson STT service to the app.
+  1) This can be done in the app dashboard after you initially deploy the app by
+     selecting `Connections` in the left menu, then clicking on the `Create connection`
+     button. After clicking on this button, you can select an existing
+     `Speech to Text` service that you have access to. Your app can be found from the IBM Cloud
+     [resource list](https://cloud.ibm.com/resources).
+  2) After connecting the service, go to `Runtime` from the left menu, and select
+     the `Environment variables` tab. You should now see the STT service in the
+     `VCAP_SERVICES` section. Take note of the `name` of the service.
+  3) Scroll down to the `User defined` environment variables section, and click `Add`, then
+     add the following key-value pair, replacing the placeholder with your service name:
+       - `STT_SERVICE_NAME:  <name of your STT service>`
+
+---
+
+The application first checks for the service in `VCAP_SERVICES` by searching for a name
+corresponding to the environment variable `STT_SERVICE_NAME`. If these don't exist,
+then the app will check for credentials in `services.json`. Some might find it preferable
+just to use the `services.json` file, and push it with the app.
+
+## Deploy the app
+
+From the root of the project run:
+
+```bash
+ibmcloud cf push
+```
+
+This will push a new app or update the app on the IBM Cloud. You can view your apps online from the
+IBM Cloud [resource list](https://cloud.ibm.com/resources).
+
+## Visit deployed app
+
+In a browser, navigate to `https://<your app route>`.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
- - name: active-learning-demo
-   random-route: true
-   memory: 1024M
+ - name: watson-stt-customizer
+   memory: 512M
+   routes:
+   - route: your-host.mybluemix.net

--- a/server/server.ts
+++ b/server/server.ts
@@ -70,6 +70,14 @@ class App {
    */
   private routes(): void {
     this.express.use('/api', router);
+    this.express.use(
+      express.static(path.join(__dirname, '..', 'client', 'build'))
+    );
+    this.express.get('/*', (req, res) => {
+      res.sendFile(
+        path.join(__dirname, '..', 'client' , 'build', 'index.html')
+      );
+    });
   }
 
   private launchConf() {
@@ -133,8 +141,9 @@ function initPassport() {
  */
 function isAuthenticated (req: express.Request, res: express.Response,
     next: express.NextFunction) {
-  if (req.isAuthenticated() || req.path === '/api/login') {
-    return next();
+  if (req.isAuthenticated() || req.path === '/api/login' ||
+    !(req.path.includes('api'))) {
+      return next();
   }
   return res.status(401).json({
     error: 'Not authorized to view this resource.'


### PR DESCRIPTION
This instructions will give some basic guidance for deploying the web app on CF in IBM Cloud. Some code modifications were added to facilitate endpoint deployments.

Closes #62 