### PR TITLE
Split larger file into 3MB chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "express-bunyan-logger": "^1.3.3",
     "express-session": "^1.15.6",
     "express-validator": "^5.3.0",
+    "ibm-watson": "^4.2.1",
     "multer": "^1.3.1",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
-    "watson-developer-cloud": "^3.18.1",
     "ws": "^6.2.0"
   }
 }


### PR DESCRIPTION
There is WebSocket frame size limitation and need to split the
the larger file into small chunks and send to Watson
API.

In the change, we also switch to `ibm-watson` npm package.

fix: #71 
Signed-off-by: Yihong Wang <yh.wang@ibm.com>