### PR TITLE
Add file check for file selection

### DIFF
--- a/client/src/pages/Audio.js
+++ b/client/src/pages/Audio.js
@@ -45,8 +45,10 @@ export default class Audio extends Component {
   }
 
   handleFileChange = event => {
-    this.file = event.target.files[0];
-    this.setState({ 'filename': this.file.name });
+    if (event.target.files.length) {
+      this.file = event.target.files[0];
+      this.setState({ 'filename': this.file.name });
+    }
   }
 
   handleDismiss = errorType => {

--- a/client/src/pages/Corpora.js
+++ b/client/src/pages/Corpora.js
@@ -45,10 +45,12 @@ export default class Corpora extends Component {
   }
 
   handleFileChange = event => {
-    this.fileReader = new FileReader();
-    this.fileReader.onloadend = () => { this.fileContents = this.fileReader.result; };
-    this.fileReader.readAsText(event.target.files[0]);
-    this.setState({ 'filename': event.target.files[0].name });
+    if (event.target.files.length) {
+      this.fileReader = new FileReader();
+      this.fileReader.onloadend = () => { this.fileContents = this.fileReader.result; };
+      this.fileReader.readAsText(event.target.files[0]);
+      this.setState({ 'filename': event.target.files[0].name });
+    }
   }
 
   handleDismiss = errorType => {

--- a/client/src/pages/Transcribe.js
+++ b/client/src/pages/Transcribe.js
@@ -189,8 +189,10 @@ export default class Transcribe extends Component {
   }
 
   handleFileChange = event => {
-    this.file = event.target.files[0];
-    this.setState({ 'filename': this.file.name });
+    if (event.target.files.length) {
+      this.file = event.target.files[0];
+      this.setState({ 'filename': this.file.name });
+    }
   }
 
   handlePanelToggle = event => {


### PR DESCRIPTION
There are cases where a user may select a file, then open the file browser again,
and then cancel before another selection is made. This raises an exception when trying
to read the file name.

This commit handles these cases.