### PR TITLE
Update pythons scripts to use env variable for endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,12 @@ Then select the `Train` tab to show the training options. Train both the `Langua
 
 ### b. Use the Command Line interface
 
-If you prefer to use the command line, set the following environment variables. Update the `<your-iam-api-key>` value with your apikey value you retrieved in [Step 3](#3-configure-credentials).
+If you prefer to use the command line, set the following environment variables. Update the `<your-iam-api-key>` and `<url>` values with the values retrieved in [Step 3](#3-configure-credentials).
 
 ```bash
 export USERNAME=apikey
 export PASSWORD=<your-iam-api-key>
+export STT_ENDPOINT=<your-url>
 ```
 
 To keep all of the generated data files in the proper directory, set the current directory to `data` before executing any of the following commands:

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -48,6 +48,7 @@ To run the Python programs, please set the following environment variables:
 ```bash
 export USERNAME=apikey
 export PASSWORD=<your_apikey>
+export STT_ENDPOINT=<your_url>
 export LANGUAGE_ID=<your_custom_language_model_id>
 export ACOUSTIC_ID=<your_custom_acoustic_model_id>
 ```

--- a/cmd/add_audio.py
+++ b/cmd/add_audio.py
@@ -17,7 +17,7 @@ audio_filename = env.get_arg("audio filename")
 print("\nAdding audio source ...")
 
 headers = {'Content-Type' : "application/zip"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"+audio_filename
+uri = env.get_endpoint() + "/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"+audio_filename
 
 with open(audio_filename, 'rb') as f:
    r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers, data=f)

--- a/cmd/add_corpus.py
+++ b/cmd/add_corpus.py
@@ -20,7 +20,7 @@ corpus_file = env.get_arg("corpus filename")
 print("\nAdding corpus file: ", corpus_file)
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/corpora/"+corpus_file
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/corpora/"+corpus_file
 with open(corpus_file, 'rb') as f:
    r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers, data=f)
 
@@ -38,7 +38,7 @@ if r.status_code != 201:
 ##########################################################################
 print("Checking status of corpus analysis...")
 
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/corpora/"+corpus_file
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/corpora/"+corpus_file
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 respJson = r.json()
 status = respJson['status']
@@ -60,7 +60,7 @@ print("Corpus analysis done!")
 ##########################################################################
 print("\nListing words...")
 
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/words?sort=count"
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/words?sort=count"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Listing words returns: ", r.status_code)

--- a/cmd/create_acoustic_model.py
+++ b/cmd/create_acoustic_model.py
@@ -17,7 +17,7 @@ print("\nCreate a new acoustic custom model: "+model_name)
 
 headers = {'Content-Type' : "application/json"}
 data = {"name" : model_name, "base_model_name" : "en-US_NarrowbandModel", "description" : "My narrowband acoustic model"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations"
+uri = env.get_endpoint() + "/v1/acoustic_customizations"
 jsonObject = json.dumps(data).encode('utf-8')
 resp = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers, data=jsonObject)
 

--- a/cmd/create_language_model.py
+++ b/cmd/create_language_model.py
@@ -17,7 +17,7 @@ print("\nCreate a new language custom model: "+model_name)
 
 headers = {'Content-Type' : "application/json"}
 data = {"name" : model_name, "base_model_name" : "en-US_NarrowbandModel", "description" : "My narrowband language model"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"
+uri = env.get_endpoint() + "/v1/customizations/"
 jsonObject = json.dumps(data).encode('utf-8')
 r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers, data=jsonObject)
 

--- a/cmd/delete_acoustic_model.py
+++ b/cmd/delete_acoustic_model.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nDeleting custom acoustic models...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations/"+env.get_acoustic_id()
+uri = env.get_endpoint() + "/v1/acoustic_customizations/"+env.get_acoustic_id()
 resp = requests.delete(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Delete acoustic models returns: ", resp.status_code)

--- a/cmd/delete_audio.py
+++ b/cmd/delete_audio.py
@@ -17,7 +17,7 @@ print("\nDeleting audio source ...")
 
 audio_name = env.get_arg("name of audio source")
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"+audio_name
+uri = env.get_endpoint() + "/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"+audio_name
 r = requests.delete(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Delete audio source returns: ", r.status_code)

--- a/cmd/delete_corpus.py
+++ b/cmd/delete_corpus.py
@@ -17,7 +17,7 @@ corpusName = env.get_arg("corpus filename")
 print("\nDeleting corpus ...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/corpora/"+corpusName
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/corpora/"+corpusName
 r = requests.delete(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Delete corpus returns: ", r.status_code)

--- a/cmd/delete_language_model.py
+++ b/cmd/delete_language_model.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nDeleting custom language model: ")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()
 resp = requests.delete(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Delete language models returns: ", resp.status_code)

--- a/cmd/env.py
+++ b/cmd/env.py
@@ -32,6 +32,15 @@ def get_password():
         sys.exit(-1)
 
 
+def get_endpoint():
+    try:
+        return os.environ['STT_ENDPOINT']
+    except:
+        print("Please set the environment variable STT_ENDPOINT to the "
+              "URL specified in your service credentials.")
+        sys.exit(-1)
+
+
 def get_language_id ():
     try:
         return os.environ['LANGUAGE_ID']

--- a/cmd/list_acoustic_model.py
+++ b/cmd/list_acoustic_model.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nGetting custom acoustic models...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations"
+uri = env.get_endpoint() + "/v1/acoustic_customizations"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Get acoustice models returns: ", r.status_code)

--- a/cmd/list_all_models.py
+++ b/cmd/list_all_models.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nGetting all models...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/models"
+uri = env.get_endpoint() + "/v1/models"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Get all models returns: ", r.status_code)

--- a/cmd/list_audio.py
+++ b/cmd/list_audio.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nGetting audio sources ...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"
+uri = env.get_endpoint() + "/v1/acoustic_customizations/"+env.get_acoustic_id()+"/audio/"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Get audio sources returns: ", r.status_code)

--- a/cmd/list_corpus.py
+++ b/cmd/list_corpus.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nGetting corpus ...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/corpora/"
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/corpora/"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Get corpus returns: ", r.status_code)

--- a/cmd/list_language_model.py
+++ b/cmd/list_language_model.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nGetting custom language models...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations"
+uri = env.get_endpoint() + "/v1/customizations"
 r = requests.get(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Get models returns: ", r.status_code)

--- a/cmd/reset_language_model.py
+++ b/cmd/reset_language_model.py
@@ -19,7 +19,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 print("\nResetting custom language model...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/reset"
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/reset"
 r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Reset model returns: ", r.status_code)

--- a/cmd/train_acoustic_model.py
+++ b/cmd/train_acoustic_model.py
@@ -11,13 +11,13 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 ##########################################################################
 # Initiates the training of a custom acoustic model with new audio resources
 # using a language model as the base
-# A status of available means that the custom model is trained and ready to use. 
+# A status of available means that the custom model is trained and ready to use.
 ##########################################################################
 
 print("\nTrain custom acoustic model...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/acoustic_customizations/"+env.get_acoustic_id()+"/train?custom_language_model_id="+env.get_language_id()
+uri = env.get_endpoint() + "/v1/acoustic_customizations/"+env.get_acoustic_id()+"/train?custom_language_model_id="+env.get_language_id()
 r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Train acoustic model returns: ", r.status_code)

--- a/cmd/train_language_model.py
+++ b/cmd/train_language_model.py
@@ -11,13 +11,13 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 ##########################################################################
 # Initiate the training of a custom language model with new resources such as
 # corpora, grammars, and custom words
-# A status of available means that the custom model is trained and ready to use. 
+# A status of available means that the custom model is trained and ready to use.
 ##########################################################################
 
 print("\nTrain custom language model...")
 
 headers = {'Content-Type' : "application/json"}
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/"+env.get_language_id()+"/train"
+uri = env.get_endpoint() + "/v1/customizations/"+env.get_language_id()+"/train"
 r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers)
 
 print("Train language model returns: ", r.status_code)

--- a/cmd/transcribe.py
+++ b/cmd/transcribe.py
@@ -22,21 +22,21 @@ print("\nTranscribe an audio using: ")
 
 try:
     language_id = "&language_customization_id="+os.environ['LANGUAGE_ID']
-    print(" - custom language model")
+    print(" - custom language model (id: %s)" % os.environ['LANGUAGE_ID'])
 except:
     language_id = ""
     print(" - base language model")
 
 try:
     acoustic_id = "&acoustic_customization_id="+os.environ['ACOUSTIC_ID']
-    print(" - custom acoustic model")
+    print(" - custom acoustic model (id: %s)" % os.environ['ACOUSTIC_ID'])
 except:
     acoustic_id = ""
     print(" - base acoustic model")
 
 
 audio_file = env.get_arg("audio file to transcribe")
-uri = "https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?model=en-US_NarrowbandModel"+language_id+acoustic_id
+uri = env.get_endpoint() + "/v1/recognize?model=en-US_NarrowbandModel"+language_id+acoustic_id
 with open(audio_file, 'rb') as f:
     r = requests.post(uri, auth=(env.get_username(),env.get_password()), verify=False, headers=headers, data=f)
 


### PR DESCRIPTION
The URL form the service credentials specified by the service instance should be used and not a hard coded value.

Fixes: #86