### PR TITLE
Remove unneeded redirect code

### DIFF
--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -39,12 +39,9 @@ export let postLogin = (req: Request, res: Response) => {
           authenticated: false
         });
       }
-      const returnTo = req.session.returnTo || '/';
-      delete req.session.returnTo;
       return res.status(200).json({
         user: req.user,
-        authenticated: true,
-        returnTo
+        authenticated: true
       });
     });
     return null;


### PR DESCRIPTION
Redirects are done in the UI, so this portion of code isn't actually needed and is causing errors with newer versions of @types/express-session.